### PR TITLE
File transform task Version 2: Task doesn't fail when it fails to transform

### DIFF
--- a/Tasks/Common/webdeployment-common-v2/fileTransformationsUtility.ts
+++ b/Tasks/Common/webdeployment-common-v2/fileTransformationsUtility.ts
@@ -80,20 +80,29 @@ export function advancedFileTransformations(isFolderBasedDeployment: boolean, ta
             
             if(isTransformationApplied) {
                 console.log(tl.loc("XDTTransformationsappliedsuccessfully"));
+            }
+            else {
+                tl.error(tl.loc('FailedToApplySpecialTransformation'));
             }            
         }
     }
 
     if(variableSubstitutionFileFormat === "xml") {
+        let isSubstitutionApplied: boolean = true;
         if(targetFiles.length == 0) { 
-            xmlSubstitutionUtility.substituteAppSettingsVariables(folderPath, isFolderBasedDeployment);
+            isSubstitutionApplied = xmlSubstitutionUtility.substituteAppSettingsVariables(folderPath, isFolderBasedDeployment);
         }
         else {            
             targetFiles.forEach(function(fileName) { 
-                xmlSubstitutionUtility.substituteAppSettingsVariables(folderPath, isFolderBasedDeployment, fileName);
+                isSubstitutionApplied = xmlSubstitutionUtility.substituteAppSettingsVariables(folderPath, isFolderBasedDeployment, fileName) || isSubstitutionApplied;
             });
         }
-        console.log(tl.loc('XMLvariablesubstitutionappliedsuccessfully'));
+        if(isSubstitutionApplied) {
+            console.log(tl.loc('XMLvariablesubstitutionappliedsuccessfully')); 
+        } 
+        else { 
+            tl.error(tl.loc('FailedToApplyXMLvariablesubstitution')); 
+        }
     }
 
     if(variableSubstitutionFileFormat === "json") {
@@ -101,7 +110,12 @@ export function advancedFileTransformations(isFolderBasedDeployment: boolean, ta
         if(!targetFiles || targetFiles.length == 0) {
             targetFiles = ["**/*.json"];
         }
-        jsonSubstitutionUtility.jsonVariableSubstitution(folderPath, targetFiles, true);
-        console.log(tl.loc('JSONvariablesubstitutionappliedsuccessfully'));
+        let isSubstitutionApplied = jsonSubstitutionUtility.jsonVariableSubstitution(folderPath, targetFiles, true);
+        if(isSubstitutionApplied) {
+            console.log(tl.loc('XMLvariablesubstitutionappliedsuccessfully')); 
+        } 
+        else { 
+            tl.error(tl.loc('FailedToApplyXMLvariablesubstitution')); 
+        }
     }
 }

--- a/Tasks/Common/webdeployment-common-v2/fileTransformationsUtility.ts
+++ b/Tasks/Common/webdeployment-common-v2/fileTransformationsUtility.ts
@@ -54,29 +54,19 @@ export function advancedFileTransformations(isFolderBasedDeployment: boolean, ta
             throw Error(tl.loc("CannotPerformXdtTransformationOnNonWindowsPlatform"));
         }
         else {
-            let isTransformationApplied: boolean = true;
-            if(transformationRules.length > 0) {                
-                transformationRules.forEach(function(rule) {
-                    var args = ParameterParser.parse(rule);
-                    if(Object.keys(args).length < 2 || !args["transform"] || !args["xml"]) {
-                       tl.error(tl.loc("MissingArgumentsforXMLTransformation"));
-                    }
-                    else if(Object.keys(args).length > 2) {
-                        isTransformationApplied = xdtTransformationUtility.specialXdtTransformation(folderPath, args["transform"].value, args["xml"].value, args["result"].value) && isTransformationApplied;
-                    }
-                    else {
-                        isTransformationApplied = xdtTransformationUtility.specialXdtTransformation(folderPath, args["transform"].value, args["xml"].value) && isTransformationApplied;
-                    }
-                });
-            }
-            else{   
-                var environmentName = tl.getVariable('Release.EnvironmentName');             
-                let transformConfigs = ["Release.config"];
-                if(environmentName && environmentName.toLowerCase() != 'release') {
-                    transformConfigs.push(environmentName + ".config");
+            let isTransformationApplied: boolean = true;              
+            transformationRules.forEach(function(rule) {
+                var args = ParameterParser.parse(rule);
+                if(Object.keys(args).length < 2 || !args["transform"] || !args["xml"]) {
+                    tl.error(tl.loc("MissingArgumentsforXMLTransformation"));
                 }
-                isTransformationApplied = xdtTransformationUtility.basicXdtTransformation(folderPath, transformConfigs);
-            }
+                else if(Object.keys(args).length > 2) {
+                    isTransformationApplied = xdtTransformationUtility.specialXdtTransformation(folderPath, args["transform"].value, args["xml"].value, args["result"].value) && isTransformationApplied;
+                }
+                else {
+                    isTransformationApplied = xdtTransformationUtility.specialXdtTransformation(folderPath, args["transform"].value, args["xml"].value) && isTransformationApplied;
+                }
+            });
             
             if(isTransformationApplied) {
                 console.log(tl.loc("XDTTransformationsappliedsuccessfully"));

--- a/Tasks/Common/webdeployment-common-v2/xdttransformationutility.ts
+++ b/Tasks/Common/webdeployment-common-v2/xdttransformationutility.ts
@@ -124,7 +124,7 @@ export function specialXdtTransformation(rootFolder, transformConfig, sourceConf
     }
     
     if(!isTransformationApplied) {
-        tl.warning(tl.loc('FailedToApplyTransformation'));
+        tl.warning(tl.loc('FailedToApplySpecialTransformation'));
     }
 
     return isTransformationApplied;

--- a/Tasks/Common/webdeployment-common-v2/xmlvariablesubstitutionutility.ts
+++ b/Tasks/Common/webdeployment-common-v2/xmlvariablesubstitutionutility.ts
@@ -161,6 +161,8 @@ export function substituteXmlVariables(configFile, tags, variableMap, parameterF
     else {
         console.log(tl.loc('SkippedUpdatingFile' , configFile));
     }
+    
+    return isSubstitutionApplied;
 }
 
 function updateXmlConfigNodeAttribute(xmlDocument, xmlNode, variableMap, replacableTokenValues, ltxDomUtiltiyInstance): boolean {

--- a/Tasks/FileTransformV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/en-US/resources.resjson
@@ -21,7 +21,8 @@
   "loc.messages.XdtTransformationErrorWhileTransforming": "XML transformation error while transforming %s using %s.",
   "loc.messages.JSONParseError": "Unable to parse JSON file: %s. Error: %s",
   "loc.messages.NOJSONfilematchedwithspecificpattern": "NO JSON file matched with specific pattern: %s.",
-  "loc.messages.FailedToApplyTransformation": "Unable to apply transformation for the given package.",
+  "loc.messages.FailedToApplySpecialTransformation": "Unable to apply transformation for the given package.",
+  "loc.messages.FailedToApplyTransformation": "Unable to apply transformation for the given package. Verify the following.",
   "loc.messages.MissingArgumentsforXMLTransformation": "Incomplete or missing arguments. Expected format -transform <transform file> -xml <source file> -result <destinamtion file>. Transformation and source file are mandatory inputs.",
   "loc.messages.SubstitutingValueonKey": "Substituting value on key: %s",
   "loc.messages.SubstitutingValueonKeyWithNumber": "Substituting value on key %s with (number) value: %s",
@@ -35,5 +36,7 @@
   "loc.messages.SubstitutingConnectionStringValue": "Substituting connectionString value for connectionString = %s with token value: %s ",
   "loc.messages.VariableSubstitutionInitiated": "Initiated variable substitution in config file : %s",
   "loc.messages.ConfigFileUpdated": "Config file : %s updated.",
-  "loc.messages.SkippedUpdatingFile": "Skipped Updating file: %s"
+  "loc.messages.SkippedUpdatingFile": "Skipped Updating file: %s",
+  "loc.messages.FailedToApplyTransformationReason1": "1. Whether the Transformation is already applied for the MSBuild generated package during build. If yes, remove the <DependentUpon> tag for each config in the csproj file and rebuild. ",
+  "loc.messages.FailedToApplyTransformationReason2": "2. Ensure that the config file and transformation files are present in the same folder inside the package."
 }

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -50,7 +50,7 @@
             "type": "multiLine",
             "label": "Transformation rules",
             "defaultValue": "-transform **\\*.Release.config -xml **\\*.config",
-            "required": false,
+            "required": true,
             "helpMarkDown": "Provide new line separated list of transformation file rules using the syntax: <br/>-transform <pathToTransformFile>  -xml <pathToSourceConfigurationFile>",
             "visibleRule": "enableXmlTransform == true"
         },

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -16,8 +16,8 @@
         "DeploymentGroup"
     ],
     "version": {
-        "Major": 1,
-        "Minor": 156,
+        "Major": 2,
+        "Minor": 0,
         "Patch": 0
     },
     "instanceNameFormat": "File Transform: $(Package)",
@@ -61,6 +61,7 @@
             "defaultValue": "",
             "required": false,
             "options": {
+                "": "Select file format",
                 "xml": "XML",
                 "json": "JSON"
             },
@@ -95,7 +96,8 @@
         "XdtTransformationErrorWhileTransforming": "XML transformation error while transforming %s using %s.",
         "JSONParseError": "Unable to parse JSON file: %s. Error: %s",
         "NOJSONfilematchedwithspecificpattern": "NO JSON file matched with specific pattern: %s.",
-        "FailedToApplyTransformation": "Unable to apply transformation for the given package.",
+        "FailedToApplySpecialTransformation": "Unable to apply transformation for the given package.",
+        "FailedToApplyTransformation": "Unable to apply transformation for the given package. Verify the following.",
         "MissingArgumentsforXMLTransformation": "Incomplete or missing arguments. Expected format -transform <transform file> -xml <source file> -result <destinamtion file>. Transformation and source file are mandatory inputs.",
         "SubstitutingValueonKey" : "Substituting value on key: %s",
         "SubstitutingValueonKeyWithNumber" : "Substituting value on key %s with (number) value: %s",
@@ -109,6 +111,8 @@
         "SubstitutingConnectionStringValue" : "Substituting connectionString value for connectionString = %s with token value: %s ",
         "VariableSubstitutionInitiated" : "Initiated variable substitution in config file : %s",
         "ConfigFileUpdated" : "Config file : %s updated.",
-        "SkippedUpdatingFile" : "Skipped Updating file: %s"
+        "SkippedUpdatingFile" : "Skipped Updating file: %s",
+        "FailedToApplyTransformationReason1": "1. Whether the Transformation is already applied for the MSBuild generated package during build. If yes, remove the <DependentUpon> tag for each config in the csproj file and rebuild. ",
+        "FailedToApplyTransformationReason2": "2. Ensure that the config file and transformation files are present in the same folder inside the package."
     }
 }

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -16,8 +16,8 @@
     "DeploymentGroup"
   ],
   "version": {
-    "Major": 1,
-    "Minor": 156,
+    "Major": 2,
+    "Minor": 0,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -61,6 +61,7 @@
       "defaultValue": "",
       "required": false,
       "options": {
+        "": "Select file format",
         "xml": "XML",
         "json": "JSON"
       },
@@ -95,6 +96,7 @@
     "XdtTransformationErrorWhileTransforming": "ms-resource:loc.messages.XdtTransformationErrorWhileTransforming",
     "JSONParseError": "ms-resource:loc.messages.JSONParseError",
     "NOJSONfilematchedwithspecificpattern": "ms-resource:loc.messages.NOJSONfilematchedwithspecificpattern",
+    "FailedToApplySpecialTransformation": "ms-resource:loc.messages.FailedToApplySpecialTransformation",
     "FailedToApplyTransformation": "ms-resource:loc.messages.FailedToApplyTransformation",
     "MissingArgumentsforXMLTransformation": "ms-resource:loc.messages.MissingArgumentsforXMLTransformation",
     "SubstitutingValueonKey": "ms-resource:loc.messages.SubstitutingValueonKey",
@@ -109,6 +111,8 @@
     "SubstitutingConnectionStringValue": "ms-resource:loc.messages.SubstitutingConnectionStringValue",
     "VariableSubstitutionInitiated": "ms-resource:loc.messages.VariableSubstitutionInitiated",
     "ConfigFileUpdated": "ms-resource:loc.messages.ConfigFileUpdated",
-    "SkippedUpdatingFile": "ms-resource:loc.messages.SkippedUpdatingFile"
+    "SkippedUpdatingFile": "ms-resource:loc.messages.SkippedUpdatingFile",
+    "FailedToApplyTransformationReason1": "ms-resource:loc.messages.FailedToApplyTransformationReason1",
+    "FailedToApplyTransformationReason2": "ms-resource:loc.messages.FailedToApplyTransformationReason2"
   }
 }


### PR DESCRIPTION
Bug #1562194 File transform task: Task doesn't fail when it fails to transform

Changes made:

The task fails when no transformations/variable substitutions occur.
Removed the default Release.envtvariable from pipeline.
Made transformation commands a mandatory field.
Moved some debug statements to console log to help the user in debugging.
Major version bump

Link to bug: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1562194